### PR TITLE
fixed App Entitlements & listed Deprecated Code.

### DIFF
--- a/.github/workflows/buildapp.yml
+++ b/.github/workflows/buildapp.yml
@@ -8,8 +8,8 @@ on:
     inputs:
       cercube_version:
         description: "The version of Cercube"
-        default: "5.3.9"
-        required: false
+        default: "5.3.11"
+        required: true
         type: string
       decrypted_youtube_url:
         description: "The direct URL to the decrypted YouTube ipa"
@@ -66,7 +66,7 @@ jobs:
       - name: Setup Theos Jailed
         uses: actions/checkout@v3
         with:
-          repository: kabiroberai/theos-jailed
+          repository: qnblackcat/theos-jailed
           ref: master
           path: theos-jailed
           submodules: recursive
@@ -99,7 +99,7 @@ jobs:
           (cd ${{ github.workspace }}/main/Tweaks/YouPiP && sed -i '' "14s/$/ AVFoundation UIKit/" Makefile)
           make package FINALPACKAGE=1
           (mv "packages/$(ls -t packages | head -n1)" "packages/CercubePlus_${{ env.YOUTUBE_VERSION  }}_${{ env.CERCUBE_VERSION }}.ipa")
-          echo "::set-output name=package::$(ls -t packages | head -n1)"
+          echo "::set-output name=package::$(ls -t packages | head -n1)" // Deprecated Code
         env:
           THEOS: ${{ github.workspace }}/theos
           CERCUBE_VERSION: ${{ inputs.cercube_version }}


### PR DESCRIPTION
**I fixed app entitlements & cercube version
and I have listed a piece of code that is now deprecated as of October 2022.**

**Read here for more information about all the decrypted warnings for build app.yml.**

## [Node JS 12 - Deprecated](https://vercel.com/changelog/node-js-12-is-being-deprecated)
## [Github save-state & set-output - Deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
## [MacOS 11 - Deprecated](https://github.com/actions/runner-images/issues/6384)


