### PR TITLE
Replace Subversion with Git (buildapp.yml)

### DIFF
--- a/.github/workflows/buildapp.yml
+++ b/.github/workflows/buildapp.yml
@@ -77,6 +77,9 @@ jobs:
           cd sdks
           git sparse-checkout set --no-cone iPhoneOS${{ inputs.sdk_version }}.sdk
           git checkout
+          mv *.sdk $THEOS/sdks
+        env:
+          THEOS: ${{ github.workspace }}/theos
 
       - name: Setup Theos Jailed
         uses: actions/checkout@v4

--- a/.github/workflows/buildapp.yml
+++ b/.github/workflows/buildapp.yml
@@ -21,6 +21,11 @@ on:
         default: ""
         required: true
         type: string
+      sdk_version:
+        description: "iOS SDK version to be used during build"
+        default: "16.2"
+        required: true
+        type: string
       create_release:
         description: "Create a draft release"
         default: true
@@ -40,7 +45,7 @@ jobs:
 
     steps:
       - name: Checkout Main
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: main
           submodules: recursive
@@ -49,7 +54,7 @@ jobs:
         run: brew install ldid dpkg
 
       - name: Setup Theos
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: theos/theos
           ref: 9941262c450c0abac524574cb96b9a4cdf5e50f4
@@ -60,19 +65,21 @@ jobs:
         id: SDK
         uses: actions/cache@v3.3.2
         env:
-          cache-name: iOS-16.2-SDK
+          cache-name: iOS-${{ inputs.sdk_version }}-SDK
         with:
           path: theos/sdks/
           key: ${{ env.cache-name }}
 
-      - name: Download iOS 16.2 SDK
+      - name: Download iOS SDK
         if: steps.SDK.outputs.cache-hit != 'true'
         run: |
-          git clone --quiet https://github.com/arichorn/sdks.git
-          mv sdks/iPhoneOS16.2.sdk $THEOS/sdks
+          git clone -n --depth=1 --filter=tree:0 https://github.com/arichorn/sdks/
+          cd sdks
+          git sparse-checkout set --no-cone iPhoneOS${{ inputs.sdk_version }}.sdk
+          git checkout
 
       - name: Setup Theos Jailed
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: qnblackcat/theos-jailed
           ref: master

--- a/.github/workflows/buildapp.yml
+++ b/.github/workflows/buildapp.yml
@@ -1,5 +1,5 @@
 # Original idea by @ISnackable. Many thanks to him for handling the most hardest parts!
-# https://github.com/ISnackable/CercubePlus/blob/main/.github/workflows/Build.yml
+# https://github.com/ISnackable/YTCubePlus/blob/main/.github/workflows/Build.yml
 
 name: Build and Release CercubePlus
 
@@ -52,29 +52,24 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: theos/theos
-          ref: 3da31488281ecf4394d10302d2629607f4a1aa07
+          ref: 9941262c450c0abac524574cb96b9a4cdf5e50f4
           path: theos
           submodules: recursive
 
       - name: Caching
         id: SDK
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v3.3.2
         env:
-          cache-name: iOS-15.5-SDK
+          cache-name: iOS-16.2-SDK
         with:
           path: theos/sdks/
           key: ${{ env.cache-name }}
 
-      - name: Download iOS 15.5 SDK
+      - name: Download iOS 16.2 SDK
         if: steps.SDK.outputs.cache-hit != 'true'
         run: |
-          curl -LO https://github.com/chrisharper22/sdks/archive/main.zip
-          TMP=$(mktemp -d)
-          unzip -qq main.zip -d $TMP
-          mv $TMP/sdks-main/*.sdk $THEOS/sdks
-          rm -r main.zip $TMP
-        env:
-          THEOS: ${{ github.workspace }}/theos
+          git clone --quiet https://github.com/arichorn/sdks.git
+          mv sdks/iPhoneOS16.2.sdk $THEOS/sdks
 
       - name: Setup Theos Jailed
         uses: actions/checkout@v3

--- a/.github/workflows/buildapp.yml
+++ b/.github/workflows/buildapp.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Download Cercube & Prepare YouTube iPA
         run: |
           curl "https://raw.githubusercontent.com/Muirey03/RemoteLog/master/RemoteLog.h" --output "$THEOS/include/RemoteLog.h"
-          # curl "https://apt.alfhaily.me/files/me.alfhaily.cercube_${{ env.CERCUBE_VERSION }}_iphoneos-arm.deb" --output "main/Tweaks/Cercube/me.alfhaily.cercube_${{ env.CERCUBE_VERSION }}_iphoneos-arm.deb"
+          # curl -L "https://apt.alfhaily.me/files/me.alfhaily.cercube_${{ env.CERCUBE_VERSION }}_iphoneos-arm.deb" --output "main/Tweaks/Cercube/me.alfhaily.cercube_${{ env.CERCUBE_VERSION }}_iphoneos-arm.deb"
           wget "$YOUTUBE_URL" --no-verbose -O main/YouTube.ipa
           dpkg-deb -x "main/Tweaks/Cercube/me.alfhaily.cercube_${{ env.CERCUBE_VERSION }}_iphoneos-arm.deb" main/Tweaks/Cercube/
           unzip -q main/YouTube.ipa -d main/tmp


### PR DESCRIPTION
Hello iSnackable!
I did a small change that can be important for this or other repositories with buildapp.yml

in this commit, I have added a `-L` to the curl where it downloads the deb, this can be useful if the URL gets redirected and gets requested to a new URL.
also I know the line is disabled, just giving you another way to stop errors like how I did with Theos 😅
